### PR TITLE
Bump react-scripts to fix error

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "react": "^16.12.0",
     "react-dom": "^16.12.0",
     "react-redux": "^7.1.3",
-    "react-scripts": "3.3.1",
+    "react-scripts": "^3.4.1",
     "redux": "^4.0.5"
   },
   "scripts": {


### PR DESCRIPTION
I was receiving `TypeError [ERR_INVALID_ARG_TYPE]: The "path" argument must be of type string. Received undefined` when running `npm install` and then `npm start` on this package. The fix suggested on [StackOverflow](https://stackoverflow.com/questions/60234640/typeerror-err-invalid-arg-type-the-path-argument-must-be-of-type-string-re) worked for me.